### PR TITLE
feat: 공용 탭스 추가

### DIFF
--- a/frontend/src/components/shared/Tabs/Tabs.css
+++ b/frontend/src/components/shared/Tabs/Tabs.css
@@ -1,0 +1,34 @@
+.tabs-header{
+    display: flex;
+    font-size: 16px;
+    font-weight: bold;
+    color: var(--light-gray-color);
+    li {
+        text-align: center;
+        flex-grow: 1;
+        padding: .8em 0 1.4em;
+        cursor: pointer;
+        span {
+            position: relative;
+            &::after {
+                content: '';
+                position: absolute;
+                width: 8px;
+                height: 8px;
+                background-color: var(--point-color);
+                border-radius: 1000px;
+                left: 50%;
+                bottom: -.6em;
+                transform: translate(-50% , 0);
+                transition: all .3s;
+                scale: 0;
+            }
+        }
+    }
+    .active {
+        color: var(--text-color);
+        span::after {
+            scale: 1;
+        }
+    }
+}

--- a/frontend/src/components/shared/Tabs/Tabs.jsx
+++ b/frontend/src/components/shared/Tabs/Tabs.jsx
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import "./Tabs.css";
+
+export const Tabs = ({defaultIdx = 0, items=[]}) => {
+    const [idx , setIdx] = useState(defaultIdx)
+    return <>
+        <ul className="tabs-header">
+            {
+                items?.map(({title}, i)=> 
+                    <li 
+                        key={title} 
+                        className={idx === i && 'active'}
+                        onClick={()=> setIdx(i)}
+                    >
+                        <span>{title}</span>
+                    </li>)
+            }
+        </ul>
+        { items[idx]?.comp }
+    </>
+}


### PR DESCRIPTION
탭스를 추가 하였습니다.
현재 탭스 라이브러리가 설치된 상황이라, 제가 만든거 쓰시려면 경로 shared 에 있는거 써주시면 됩니다.

![image](https://github.com/user-attachments/assets/f7306745-e621-4661-90f7-89e0815dcd4a)
이동 잘 됩니다.

props 
1. items = 렌더링할 탭스 아이템 배열을 넣어주세요
예) [
{
  title : 'Feed',
  comp : <>피드탭</>
},
{
  title : 'Dash board',
  comp : <>대시보드탭</>
},
]
2. defaultIdx = 처음에 보여줄 탭 인덱스입니다. 기본값은 0 입니다